### PR TITLE
am: Remove extraneous boostage

### DIFF
--- a/services/core/java/com/android/server/am/ActivityStackSupervisor.java
+++ b/services/core/java/com/android/server/am/ActivityStackSupervisor.java
@@ -1453,8 +1453,6 @@ public final class ActivityStackSupervisor implements DisplayListener {
                             Display.DEFAULT_DISPLAY : mFocusedStack.mDisplayId) :
                             (container.mActivityDisplay == null ? Display.DEFAULT_DISPLAY :
                                     container.mActivityDisplay.mDisplayId)));
-            /* Acquire perf lock during new app launch */
-            mService.launchBoost(-1, aInfo.packageName);
         }
 
         ActivityRecord sourceRecord = null;


### PR DESCRIPTION
 * Not necessary, and it's apparently possible for ainfo to be null
   here.  Remove the boost.

Change-Id: I53d052a2949d2b46b5a219113d53a001c7979024